### PR TITLE
Make business model optional

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -51,6 +51,7 @@ collections:
           name: "businessModel",
           widget: "select",
           multiple: true,
+          required: false,
           options:
             [
               { label: "Open Source", value: "open-source" },

--- a/src/types/Blip.ts
+++ b/src/types/Blip.ts
@@ -8,7 +8,7 @@ export interface Blip {
   license: string;
   ring: keyof typeof Rings;
   quadrant: keyof typeof Quadrants;
-  businessModel: (keyof typeof BusinessModel)[];
+  businessModel?: (keyof typeof BusinessModel)[];
   projectIds: string[];
   projects?: Project[];
   slug: string;


### PR DESCRIPTION
Fix #84.

The rendering code already consider it optional.
I just had to make a change in the CMS config and the type itself.